### PR TITLE
chore: v1

### DIFF
--- a/src/parser.cairo
+++ b/src/parser.cairo
@@ -1,0 +1,73 @@
+use core::byte_array::{ByteArray, ByteArrayTrait};
+use core::result::{Result};
+use super::JsonDeserialize;
+
+pub mod json_parser {
+    use super::{ByteArray, ByteArrayTrait, Result};
+
+    pub fn skip_whitespace(data: @ByteArray, ref pos: usize) {
+        let space = 32_u8;
+        let newline = 10_u8;
+        let tab = 9_u8;
+        while pos < data.len() && (data[pos] == space || data[pos] == newline || data[pos] == tab) {
+            pos += 1;
+        }
+    }
+
+    pub fn parse_string(data: @ByteArray, ref pos: usize) -> Result<ByteArray, ByteArray> {
+        if pos >= data.len() || data[pos] != 34_u8 { // '"'
+            let error: ByteArray = "Expected string quote";
+            return Result::Err(error);
+        }
+        pos += 1;
+        let mut result: ByteArray = "";
+        while pos < data.len() && data[pos] != 34_u8 {
+            result.append_byte(data[pos]);
+            pos += 1;
+        };
+        if pos >= data.len() {
+            let error: ByteArray = "Unterminated string";
+            return Result::Err(error);
+        }
+        pos += 1;
+        Result::Ok(result)
+    }
+
+    pub fn parse_u64(data: @ByteArray, ref pos: usize) -> Result<u64, ByteArray> {
+        skip_whitespace(data, ref pos);
+        let mut num: u64 = 0;
+        let mut has_digits = false;
+        while pos < data.len() && (data[pos] >= 48_u8 && data[pos] <= 57_u8) {
+            num = num * 10 + (data[pos] - 48_u8).into();
+            pos += 1;
+            has_digits = true;
+        };
+        if !has_digits {
+            let error: ByteArray = "Expected number";
+            return Result::Err(error);
+        };
+        Result::Ok(num)
+    }
+    
+    pub fn parse_object<T, impl TDeserialize: super::JsonDeserialize<T>, impl TDrop: Drop<T>>(
+    data: @ByteArray, ref pos: usize
+) -> Result<T, ByteArray> {
+    if pos >= data.len() || data[pos] != 123_u8 { // '{'
+        return Result::Err("Expected object");
+    }
+    pos += 1;
+    skip_whitespace(data, ref pos);
+    
+    let result = TDeserialize::deserialize(data, ref pos);
+    
+    let obj = result?; // This propagates error immediately
+    
+    skip_whitespace(data, ref pos);
+    if pos >= data.len() || data[pos] != 125_u8 { // '}'
+        return Result::Err("Expected closing brace");
+    }
+    pos += 1;
+    
+    Result::Ok(obj)
+    }
+}

--- a/src/parser.cairo
+++ b/src/parser.cairo
@@ -16,21 +16,59 @@ pub mod json_parser {
 
     pub fn parse_string(data: @ByteArray, ref pos: usize) -> Result<ByteArray, ByteArray> {
         if pos >= data.len() || data[pos] != 34_u8 { // '"'
-            let error: ByteArray = "Expected string quote";
+            let error: ByteArray = "Expected string quote at position "; // + pos.try_into();
             return Result::Err(error);
         }
         pos += 1;
         let mut result: ByteArray = "";
-        while pos < data.len() && data[pos] != 34_u8 {
-            result.append_byte(data[pos]);
-            pos += 1;
+        let mut success: bool = true;
+        let mut error: ByteArray = "";
+
+        while pos < data.len() && data[pos] != 34_u8 && success {
+            if data[pos] == 92_u8 { // '\'
+                pos += 1;
+                if pos >= data.len() {
+                    error = "Unterminated string at position "; // + pos.try_into();
+                    success = false;
+                    break;
+                }
+                let escape_char = data[pos];
+                if escape_char == 34_u8 { // '\"' -> '"'
+                    result.append_byte(34_u8);
+                } else if escape_char == 92_u8 { // '\\' -> '\'
+                    result.append_byte(92_u8);
+                } else if escape_char == 47_u8 { // '\/' -> '/'
+                    result.append_byte(47_u8);
+                } else if escape_char == 98_u8 { // '\b' -> backspace
+                    result.append_byte(8_u8);
+                } else if escape_char == 102_u8 { // '\f' -> form feed
+                    result.append_byte(12_u8);
+                } else if escape_char == 110_u8 { // '\n' -> newline
+                    result.append_byte(10_u8);
+                } else if escape_char == 114_u8 { // '\r' -> carriage return
+                    result.append_byte(13_u8);
+                } else if escape_char == 116_u8 { // '\t' -> tab
+                    result.append_byte(9_u8);
+                } else {
+                    error = "Invalid escape sequence at position ";
+                    break;
+                }
+                pos += 1;
+            } else {
+                result.append_byte(data[pos]);
+                pos += 1;
+            }
         };
-        if pos >= data.len() {
-            let error: ByteArray = "Unterminated string";
-            return Result::Err(error);
+
+        if !success {
+            Result::Err(error)
+        } else if pos >= data.len() || data[pos] != 34_u8 {
+            let error: ByteArray = "Unterminated string at position "; // + pos.try_into();
+            Result::Err(error)
+        } else {
+            pos += 1;
+            Result::Ok(result)
         }
-        pos += 1;
-        Result::Ok(result)
     }
 
     pub fn parse_u64(data: @ByteArray, ref pos: usize) -> Result<u64, ByteArray> {
@@ -48,26 +86,26 @@ pub mod json_parser {
         };
         Result::Ok(num)
     }
-    
+
     pub fn parse_object<T, impl TDeserialize: super::JsonDeserialize<T>, impl TDrop: Drop<T>>(
-    data: @ByteArray, ref pos: usize
-) -> Result<T, ByteArray> {
-    if pos >= data.len() || data[pos] != 123_u8 { // '{'
-        return Result::Err("Expected object");
-    }
-    pos += 1;
-    skip_whitespace(data, ref pos);
-    
-    let result = TDeserialize::deserialize(data, ref pos);
-    
-    let obj = result?; // This propagates error immediately
-    
-    skip_whitespace(data, ref pos);
-    if pos >= data.len() || data[pos] != 125_u8 { // '}'
-        return Result::Err("Expected closing brace");
-    }
-    pos += 1;
-    
-    Result::Ok(obj)
+        data: @ByteArray, ref pos: usize
+    ) -> Result<T, ByteArray> {
+        if pos >= data.len() || data[pos] != 123_u8 { // '{'
+            return Result::Err("Expected object");
+        }
+        pos += 1;
+        skip_whitespace(data, ref pos);
+
+        let result = TDeserialize::deserialize(data, ref pos);
+
+        let obj = result?; // This propagates error immediately
+
+        skip_whitespace(data, ref pos);
+        if pos >= data.len() || data[pos] != 125_u8 { // '}'
+            return Result::Err("Expected closing brace");
+        }
+        pos += 1;
+
+        Result::Ok(obj)
     }
 }

--- a/src/traits.cairo
+++ b/src/traits.cairo
@@ -1,0 +1,5 @@
+use core::byte_array::ByteArray;
+
+pub trait JsonDeserialize<T> {
+    fn deserialize(data: @ByteArray, ref pos: usize) -> Result<T, ByteArray>;
+}

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -1,47 +1,180 @@
-use starknet::ContractAddress;
+use serde_json::json_parser;
+use serde_json::deserialize_from_byte_array;
+use core::byte_array::{ByteArray, ByteArrayTrait};
+use serde_json::JsonDeserialize;
 
-use snforge_std::{declare, ContractClassTrait, DeclareResultTrait};
-
-use serde_json::IHelloStarknetSafeDispatcher;
-use serde_json::IHelloStarknetSafeDispatcherTrait;
-use serde_json::IHelloStarknetDispatcher;
-use serde_json::IHelloStarknetDispatcherTrait;
-
-fn deploy_contract(name: ByteArray) -> ContractAddress {
-    let contract = declare(name).unwrap().contract_class();
-    let (contract_address, _) = contract.deploy(@ArrayTrait::new()).unwrap();
-    contract_address
+// Define the Post struct
+#[derive(Drop)]
+struct Post {
+    user: ByteArray,
+    message: ByteArray,
+    timestamp: u64
 }
 
-#[test]
-fn test_increase_balance() {
-    let contract_address = deploy_contract("HelloStarknet");
-
-    let dispatcher = IHelloStarknetDispatcher { contract_address };
-
-    let balance_before = dispatcher.get_balance();
-    assert(balance_before == 0, 'Invalid balance');
-
-    dispatcher.increase_balance(42);
-
-    let balance_after = dispatcher.get_balance();
-    assert(balance_after == 42, 'Invalid balance');
+// Trait definition for deserialization
+trait PostDeserialize<T> {
+    fn deserialize(data: @ByteArray, ref pos: usize) -> Result<Post, ByteArray>;
 }
+impl PostDeserializeImpl of PostDeserialize<Post> {
+    fn deserialize(data: @ByteArray, ref pos: usize) -> Result<Post, ByteArray> {
+        // Now just parse the object fields.
+        let mut user: ByteArray = "";
+        let mut message: ByteArray = "";
+        let mut timestamp: u64 = 0;
+        let mut user_parsed = false;
+        let mut message_parsed = false;
+        let mut timestamp_parsed = false;
+        let mut error: ByteArray = "";
+        let mut success = true;
 
-#[test]
-#[feature("safe_dispatcher")]
-fn test_cannot_increase_balance_with_zero_value() {
-    let contract_address = deploy_contract("HelloStarknet");
+        loop {
+            json_parser::skip_whitespace(data, ref pos);
+            let current_char = data.at(pos).unwrap();
+            // Here we expect a closing brace, but we let the external parser (parse_object) check that.
+            if current_char == 125_u8 { // '}'
+                break;
+            }
 
-    let safe_dispatcher = IHelloStarknetSafeDispatcher { contract_address };
+            // Parse field name.
+            match json_parser::parse_string(data, ref pos) {
+                Result::Ok(field_name) => {
+                    json_parser::skip_whitespace(data, ref pos);
+                    if data.at(pos).unwrap() != 58_u8 { // ':'
+                        error = "Expected ':'";
+                        success = false;
+                        break;
+                    }
+                    pos += 1;
 
-    let balance_before = safe_dispatcher.get_balance().unwrap();
-    assert(balance_before == 0, 'Invalid balance');
+                    if field_name == "user" {
+                        match json_parser::parse_string(data, ref pos) {
+                            Result::Ok(value) => {
+                                user = value;
+                                user_parsed = true;
+                            },
+                            Result::Err(_) => {
+                                error = "Failed to parse user";
+                                success = false;
+                                break;
+                            }
+                        }
+                    } else if field_name == "message" {
+                        match json_parser::parse_string(data, ref pos) {
+                            Result::Ok(value) => {
+                                message = value;
+                                message_parsed = true;
+                            },
+                            Result::Err(_) => {
+                                error = "Failed to parse message";
+                                success = false;
+                                break;
+                            }
+                        }
+                    } else if field_name == "timestamp" {
+                        match json_parser::parse_u64(data, ref pos) {
+                            Result::Ok(value) => {
+                                timestamp = value;
+                                timestamp_parsed = true;
+                            },
+                            Result::Err(_) => {
+                                error = "Invalid timestamp";
+                                success = false;
+                                break;
+                            }
+                        }
+                    } else {
+                        error = "Unknown field";
+                        success = false;
+                        break;
+                    }
+                },
+                Result::Err(_) => {
+                    error = "Failed to parse field name";
+                    success = false;
+                    break;
+                }
+            };
 
-    match safe_dispatcher.increase_balance(0) {
-        Result::Ok(_) => core::panic_with_felt252('Should have panicked'),
-        Result::Err(panic_data) => {
-            assert(*panic_data.at(0) == 'Amount cannot be 0', *panic_data.at(0));
+            json_parser::skip_whitespace(data, ref pos);
+            let next_char = data.at(pos).unwrap();
+            if next_char == 44_u8 { // ','
+                pos += 1;
+            } else if next_char != 125_u8 { // Not '}'
+                let mut debug_msg: ByteArray = "Unexpected char: ";
+                debug_msg.append_byte(next_char);
+                error = debug_msg;
+                success = false;
+                break;
+            }
+        };
+
+        if !success {
+            Result::Err(error)
+        } else if !user_parsed || !message_parsed || !timestamp_parsed {
+            Result::Err("Missing required field")
+        } else {
+            Result::Ok(Post { user, message, timestamp })
         }
-    };
+    }
+}
+
+// Implement JsonDeserialize for Post
+impl PostJsonDeserialize of JsonDeserialize<Post> {
+    fn deserialize(data: @ByteArray, ref pos: usize) -> Result<Post, ByteArray> {
+        PostDeserialize::<Post>::deserialize(data, ref pos)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Post, deserialize_from_byte_array};
+    use core::byte_array::ByteArray;
+    use core::panic_with_felt252;
+
+    #[test]
+    fn test_correct_deserialization() {
+        let json: ByteArray = "{\"user\":\"john\",\"message\":\"hello\",\"timestamp\":1704748800}";
+        let result = deserialize_from_byte_array::<Post>(json);
+        match result {
+            Result::Ok(post) => {
+                assert(post.user == "john", 'user should be john');
+                assert(post.message == "hello", 'message should be hello');
+                assert(post.timestamp == 1704748800, 'timestamp should match');
+            },
+            Result::Err(e) => {
+                println!("error: {}", e);
+                panic_with_felt252('Deserialization failed');
+            }
+        }
+    }
+
+    #[test]
+    fn test_invalid_json() {
+        let json: ByteArray = "not_a_json";
+        let result = deserialize_from_byte_array::<Post>(json);
+        match result {
+            Result::Ok(_) => panic(array!['Expected failure']),
+            Result::Err(e) => assert(e == "Expected object", 'Wrong error'),
+        }
+    }
+
+    #[test]
+    fn test_missing_braces() {
+        let json: ByteArray = "user:john";
+        let result = deserialize_from_byte_array::<Post>(json);
+        match result {
+            Result::Ok(_) => panic(array!['Expected failure']),
+            Result::Err(e) => assert(e == "Expected object", 'Wrong error'),
+        }
+    }
+
+    #[test]
+    fn test_invalid_timestamp() {
+        let json: ByteArray = "{\"user\":\"john\",\"message\":\"hello\",\"timestamp\":\"not_a_number\"}";
+        let result = deserialize_from_byte_array::<Post>(json);
+        match result {
+            Result::Ok(_) => panic(array!['Expected failure']),
+            Result::Err(e) => assert(e == "Invalid timestamp", 'Wrong error'), // Adjusted to match "Invalid timestamp"
+        }
+    }
 }


### PR DESCRIPTION
This pull request introduces significant changes to the codebase, focusing on implementing a new JSON deserialization module. The most important changes include the addition of JSON parsing functions, and the implementation of deserialization traits and tests.

JSON parsing functions:

* Added a new module `parser` in `src/parser.cairo` with functions for parsing JSON strings, numbers, and objects, such as `skip_whitespace`, `parse_string`, `parse_u64`, and `parse_object`.

Deserialization traits:

* Introduced a new trait `JsonDeserialize` in `src/traits.cairo` for deserializing JSON data into Rust structs.

New deserialization function:

* Added a new function `deserialize_from_byte_array` in `src/lib.cairo` to deserialize JSON data from a byte array using the `JsonDeserialize` trait.

Tests for JSON deserialization:

* Updated `tests/test_contract.cairo` to include tests for the new JSON deserialization functionality. These tests cover scenarios such as correct deserialization, invalid JSON, missing braces, and invalid timestamp.