### PR TITLE
feat: fix import issue

### DIFF
--- a/packages/serde_json/src/parser.cairo
+++ b/packages/serde_json/src/parser.cairo
@@ -1,9 +1,10 @@
 use core::byte_array::{ByteArray, ByteArrayTrait};
 use core::result::{Result};
 use super::JsonDeserialize;
+use core::array::{ArrayTrait, Array};
 
 pub mod json_parser {
-    use super::{ByteArray, ByteArrayTrait, Result};
+    use super::{ByteArray, ByteArrayTrait, Result, ArrayTrait, Array};
 
     pub fn skip_whitespace(data: @ByteArray, ref pos: usize) {
         let space = 32_u8;
@@ -107,5 +108,79 @@ pub mod json_parser {
         pos += 1;
 
         Result::Ok(obj)
+    }
+
+    pub fn parse_array<T, impl TDeserialize: super::JsonDeserialize<T>, impl TDrop: Drop<T>>(
+        data: @ByteArray, ref pos: usize
+    ) -> Result<Array<T>, ByteArray> {
+        skip_whitespace(data, ref pos);
+        if pos >= data.len() || data[pos] != 91_u8 { // '['
+            return Result::Err("Expected array opening bracket");
+        }
+        pos += 1;
+        
+        let mut result = array![];
+        skip_whitespace(data, ref pos);
+        
+        if pos < data.len() && data[pos] == 93_u8 { // ']'
+            pos += 1;
+            return Result::Ok(result);
+        }
+        
+        let mut success = true;
+        let mut error: ByteArray = "";
+        
+        loop {
+            match TDeserialize::deserialize(data, ref pos) {
+                Result::Ok(value) => {
+                    result.append(value);
+                },
+                Result::Err(err) => {
+                    error = err;
+                    success = false;
+                    break;
+                }
+            };
+            
+            skip_whitespace(data, ref pos);
+            if pos >= data.len() {
+                error = "Unterminated array";
+                success = false;
+                break;
+            }
+            let next_char = data[pos];
+            if next_char == 93_u8 { // ']'
+                pos += 1;
+                break;
+            }
+            if next_char != 44_u8 { // ','
+                error = "Expected comma or array closing bracket";
+                success = false;
+                break;
+            }
+            pos += 1;
+            skip_whitespace(data, ref pos);
+        };
+        
+        if success {
+            Result::Ok(result)
+        } else {
+            Result::Err(error)
+        }
+    }
+
+    pub fn parse_bool(data: @ByteArray, ref pos: usize) -> Result<bool, ByteArray> {
+        skip_whitespace(data, ref pos);
+        if pos + 4 <= data.len() && data[pos] == 116_u8 && data[pos + 1] == 114_u8 && 
+           data[pos + 2] == 117_u8 && data[pos + 3] == 101_u8 { // "true"
+            pos += 4;
+            Result::Ok(true)
+        } else if pos + 5 <= data.len() && data[pos] == 102_u8 && data[pos + 1] == 97_u8 && 
+                  data[pos + 2] == 108_u8 && data[pos + 3] == 115_u8 && data[pos + 4] == 101_u8 { // "false"
+            pos += 5;
+            Result::Ok(false)
+        } else {
+            Result::Err("Expected boolean value")
+        }
     }
 }

--- a/packages/serde_json/src/traits.cairo
+++ b/packages/serde_json/src/traits.cairo
@@ -1,5 +1,33 @@
 use core::byte_array::ByteArray;
+use super::parser::json_parser;
 
 pub trait JsonDeserialize<T> {
     fn deserialize(data: @ByteArray, ref pos: usize) -> Result<T, ByteArray>;
+}
+
+// Implement JsonDeserialize for bool
+impl BoolJsonDeserialize of JsonDeserialize<bool> {
+    fn deserialize(data: @ByteArray, ref pos: usize) -> Result<bool, ByteArray> {
+        json_parser::parse_bool(data, ref pos)
+    }
+}
+
+// Implement JsonDeserialize for u64
+impl U64JsonDeserialize of JsonDeserialize<u64> {
+    fn deserialize(data: @ByteArray, ref pos: usize) -> Result<u64, ByteArray> {
+        json_parser::parse_u64(data, ref pos)
+    }
+}
+
+// Implement JsonDeserialize for ByteArray
+impl ByteArrayJsonDeserialize of JsonDeserialize<ByteArray> {
+    fn deserialize(data: @ByteArray, ref pos: usize) -> Result<ByteArray, ByteArray> {
+        json_parser::parse_string(data, ref pos)
+    }
+}
+
+impl ArrayJsonDeserialize<T, impl TDeserialize: JsonDeserialize<T>, impl TDrop: Drop<T>> of JsonDeserialize<Array<T>> {
+    fn deserialize(data: @ByteArray, ref pos: usize) -> Result<Array<T>, ByteArray> {
+        json_parser::parse_array::<T, TDeserialize, TDrop>(data, ref pos)
+    }
 }

--- a/packages/serde_json/tests/test.cairo
+++ b/packages/serde_json/tests/test.cairo
@@ -1,38 +1,42 @@
 use serde_json::json_parser;
 use serde_json::deserialize_from_byte_array;
 use core::byte_array::{ByteArray, ByteArrayTrait};
+use core::array::{Array, ArrayTrait};
 use serde_json::JsonDeserialize;
 
 #[derive(Drop, Default, SerdeJson)]
 struct User {
     name: ByteArray,
     age: u64,
+    verified: bool
 }
 
-// Define the Post struct
 #[derive(Drop, SerdeJson)]
 struct Post {
     user: User,
     message: ByteArray,
+    comments: Array<ByteArray>,
     timestamp: u64,
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{Post, deserialize_from_byte_array};
+    use super::{Post, User, deserialize_from_byte_array};
     use core::byte_array::ByteArray;
     use core::panic_with_felt252;
 
     #[test]
     fn test_correct_deserialization() {
         let json: ByteArray =
-            "{\"user\":{\"name\":\"john\",\"age\":42},\"message\":\"hello\",\"timestamp\":1704748800}";
+            "{\"user\":{\"name\":\"john\",\"age\":42,\"verified\":false},\"message\":\"hello\",\"comments\":[],\"timestamp\":1704748800}";
         let result = deserialize_from_byte_array::<Post>(json);
         match result {
             Result::Ok(post) => {
                 assert(post.user.name == "john", 'user name should be john');
                 assert(post.user.age == 42, 'user age should be 42');
+                assert(!post.user.verified, 'verified should be false');
                 assert(post.message == "hello", 'message should be hello');
+                assert(post.comments.len() == 0, 'comments should be empty');
                 assert(post.timestamp == 1704748800, 'timestamp should match');
             },
             Result::Err(e) => {
@@ -65,11 +69,72 @@ mod tests {
     #[test]
     fn test_invalid_timestamp() {
         let json: ByteArray =
-            "{\"user\":{\"name\":\"john\",\"age\":42},\"message\":\"hello\",\"timestamp\":\"not_a_number\"}";
+            "{\"user\":{\"name\":\"john\",\"age\":42,\"verified\":false},\"message\":\"hello\",\"comments\":[],\"timestamp\":\"not_a_number\"}";
         let result = deserialize_from_byte_array::<Post>(json);
         match result {
             Result::Ok(_) => panic(array!['Expected failure']),
             Result::Err(e) => assert(e == "Failed to parse timestamp", 'Wrong error'),
+        }
+    }
+
+    #[test]
+    fn test_user_with_bool() {
+        let json: ByteArray = "{\"name\":\"alice\",\"age\":25,\"verified\":true}";
+        let result = deserialize_from_byte_array::<User>(json);
+        match result {
+            Result::Ok(user) => {
+                assert(user.name == "alice", 'name should be alice');
+                assert(user.age == 25, 'age should be 25');
+                assert(user.verified, 'verified should be true');
+            },
+            Result::Err(e) => {
+                println!("error: {}", e);
+                panic_with_felt252('Deserialization failed');
+            },
+        }
+    }
+
+    #[test]
+    fn test_post_with_array() {
+        let json: ByteArray = 
+            "{\"user\":{\"name\":\"john\",\"age\":42,\"verified\":false},\"message\":\"hello\",\"comments\":[\"nice\",\"cool\"],\"timestamp\":1704748800}";
+        let result = deserialize_from_byte_array::<Post>(json);
+        match result {
+            Result::Ok(post) => {
+                assert(post.user.name == "john", 'user name should be john');
+                assert(post.user.age == 42, 'user age should be 42');
+                assert(!post.user.verified, 'verified should be false');
+                assert(post.message == "hello", 'message should be hello');
+                assert(post.comments.len() == 2, 'should have 2 comments');
+                assert(post.comments[0] == @"nice", 'first comment wrong');
+                assert(post.comments[1] == @"cool", 'second comment wrong');
+                assert(post.timestamp == 1704748800, 'timestamp should match');
+            },
+            Result::Err(e) => {
+                println!("error: {}", e);
+                panic_with_felt252('Deserialization failed');
+            },
+        }
+    }
+
+    #[test]
+    fn test_invalid_bool() {
+        let json: ByteArray = "{\"name\":\"alice\",\"age\":25,\"verified\":\"not_a_bool\"}";
+        let result = deserialize_from_byte_array::<User>(json);
+        match result {
+            Result::Ok(_) => panic(array!['Expected failure']),
+            Result::Err(e) => assert(e == "Failed to parse verified", 'Wrong error'),
+        }
+    }
+
+    #[test]
+    fn test_invalid_array() {
+        let json: ByteArray = 
+            "{\"user\":{\"name\":\"john\",\"age\":42,\"verified\":false},\"message\":\"hello\",\"comments\":\"not_an_array\",\"timestamp\":1704748800}";
+        let result = deserialize_from_byte_array::<Post>(json);
+        match result {
+            Result::Ok(_) => panic(array!['Expected failure']),
+            Result::Err(e) => assert(e == "Failed to parse comments", 'Wrong error'),
         }
     }
 }

--- a/packages/serde_json_macro/src/lib.rs
+++ b/packages/serde_json_macro/src/lib.rs
@@ -45,6 +45,10 @@ pub fn serde_json(token_stream: TokenStream) -> ProcMacroResult {
             "parse_u64"
         } else if member_type == "ByteArray" {
             "parse_string"
+        } else if member_type == "bool" {
+            "parse_bool"
+        } else if member_type.starts_with("Array<") && member_type.ends_with(">") {
+            "parse_array"
         } else {
             "parse_object"
         };


### PR DESCRIPTION
This pull request introduces new functionality to the `serde_json` package, adding support for parsing and deserializing arrays and boolean values. It also includes corresponding tests to ensure the new features work correctly.

### Enhancements to JSON parsing:

* [`packages/serde_json/src/parser.cairo`](diffhunk://#diff-8c1d6974df47b6fa1a8c30c78c4e55bc0df95dbee10e1dd2f5d0208e87e1c00aR112-R185): Added functions `parse_array` and `parse_bool` to handle parsing of JSON arrays and boolean values.

### Enhancements to JSON deserialization:

* [`packages/serde_json/src/traits.cairo`](diffhunk://#diff-0b60b41dfb4bf9d6af75083a5d0f73267bf5bf51077483ec7f851f6d08d6cae6R2-R33): Implemented `JsonDeserialize` for `bool`, `u64`, `ByteArray`, and `Array<T>`.

### Test additions:

* [`packages/serde_json/tests/test.cairo`](diffhunk://#diff-257215459358672af88c356e8ebbe789f37b3bbc4e2d8983196296a27cffffeeR4-R39): Added tests for deserializing `User` and `Post` structs with boolean and array fields, including edge cases for invalid inputs. [[1]](diffhunk://#diff-257215459358672af88c356e8ebbe789f37b3bbc4e2d8983196296a27cffffeeR4-R39) [[2]](diffhunk://#diff-257215459358672af88c356e8ebbe789f37b3bbc4e2d8983196296a27cffffeeL68-R139)

### Macro updates:

* [`packages/serde_json_macro/src/lib.rs`](diffhunk://#diff-b8f9bbfcd0c74c299620a15984617a9486efc1d65ebc82f256f0827ea8d7a465R48-R51): Updated the `serde_json` macro to handle `bool` and `Array<T>` types.

Closes #8 
Closes #9 