### PR TITLE
feat: fix import issue

### DIFF
--- a/packages/serde_json/src/lib.cairo
+++ b/packages/serde_json/src/lib.cairo
@@ -1,11 +1,11 @@
 pub mod parser;
 pub mod traits;
+use core::byte_array::ByteArray;
+use core::result::Result;
+use core::traits::Drop;
 
 pub use parser::json_parser;
 pub use traits::JsonDeserialize;
-use core::byte_array::ByteArray;
-use core::result::{Result};
-use core::traits::Drop;
 
 pub fn deserialize_from_byte_array<T, impl TDeserialize: JsonDeserialize<T>, impl TDrop: Drop<T>>(
     json_data: ByteArray,

--- a/packages/serde_json/src/traits.cairo
+++ b/packages/serde_json/src/traits.cairo
@@ -13,6 +13,13 @@ impl BoolJsonDeserialize of JsonDeserialize<bool> {
 }
 
 // Implement JsonDeserialize for u64
+impl U32JsonDeserialize of JsonDeserialize<u32> {
+    fn deserialize(data: @ByteArray, ref pos: usize) -> Result<u32, ByteArray> {
+        json_parser::parse_u32(data, ref pos)
+    }
+}
+
+// Implement JsonDeserialize for u64
 impl U64JsonDeserialize of JsonDeserialize<u64> {
     fn deserialize(data: @ByteArray, ref pos: usize) -> Result<u64, ByteArray> {
         json_parser::parse_u64(data, ref pos)
@@ -40,7 +47,9 @@ impl ByteArrayJsonDeserialize of JsonDeserialize<ByteArray> {
     }
 }
 
-impl ArrayJsonDeserialize<T, impl TDeserialize: JsonDeserialize<T>, impl TDrop: Drop<T>> of JsonDeserialize<Array<T>> {
+impl ArrayJsonDeserialize<
+    T, impl TDeserialize: JsonDeserialize<T>, impl TDrop: Drop<T>,
+> of JsonDeserialize<Array<T>> {
     fn deserialize(data: @ByteArray, ref pos: usize) -> Result<Array<T>, ByteArray> {
         json_parser::parse_array::<T, TDeserialize, TDrop>(data, ref pos)
     }

--- a/packages/serde_json/tests/test.cairo
+++ b/packages/serde_json/tests/test.cairo
@@ -1,22 +1,20 @@
-use serde_json::json_parser;
-use serde_json::deserialize_from_byte_array;
+use core::array::Array;
 use core::byte_array::{ByteArray, ByteArrayTrait};
-use core::array::{Array};
-use serde_json::JsonDeserialize;
+use serde_json::{JsonDeserialize, deserialize_from_byte_array, json_parser};
 
 #[derive(Drop, Default, SerdeJson)]
 struct Event {
     id: felt252,
     name: ByteArray,
     active: bool,
-    timestamp: u256
+    timestamp: u256,
 }
 
 #[derive(Drop, Default, SerdeJson)]
 struct User {
     name: ByteArray,
     age: u64,
-    verified: bool
+    verified: bool,
 }
 
 #[derive(Drop, SerdeJson)]
@@ -30,14 +28,14 @@ struct Post {
 #[derive(Drop, SerdeJson, Default)]
 struct TestBigNumber {
     test_value: u128,
-    description: ByteArray
+    description: ByteArray,
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{Post, User, Event, TestBigNumber, deserialize_from_byte_array};
     use core::byte_array::ByteArray;
     use core::panic_with_felt252;
+    use super::{Event, Post, TestBigNumber, User, deserialize_from_byte_array};
 
     #[test]
     fn test_correct_deserialization() {
@@ -110,7 +108,7 @@ mod tests {
 
     #[test]
     fn test_post_with_array() {
-        let json: ByteArray = 
+        let json: ByteArray =
             "{\"user\":{\"name\":\"john\",\"age\":42,\"verified\":false},\"message\":\"hello\",\"comments\":[\"nice\",\"cool\"],\"timestamp\":1704748800}";
         let result = deserialize_from_byte_array::<Post>(json);
         match result {
@@ -143,7 +141,7 @@ mod tests {
 
     #[test]
     fn test_invalid_array() {
-        let json: ByteArray = 
+        let json: ByteArray =
             "{\"user\":{\"name\":\"john\",\"age\":42,\"verified\":false},\"message\":\"hello\",\"comments\":\"not_an_array\",\"timestamp\":1704748800}";
         let result = deserialize_from_byte_array::<Post>(json);
         match result {
@@ -154,14 +152,19 @@ mod tests {
 
     #[test]
     fn test_event_with_felt252() {
-        let json: ByteArray = "{\"id\":123456,\"name\":\"launch\",\"active\":true,\"timestamp\":115792089237316195423570985008687907853269984665640564039457584007913129639935}";
+        let json: ByteArray =
+            "{\"id\":123456,\"name\":\"launch\",\"active\":true,\"timestamp\":115792089237316195423570985008687907853269984665640564039457584007913129639935}";
         let result = deserialize_from_byte_array::<Event>(json);
         match result {
             Result::Ok(event) => {
                 assert(event.id == 123456, 'id should be 123456');
                 assert(event.name == "launch", 'name should be launch');
                 assert(event.active, 'active should be true');
-                assert(event.timestamp == 115792089237316195423570985008687907853269984665640564039457584007913129639935_u256, 'timestamp should be max u256');
+                assert(
+                    event
+                        .timestamp == 115792089237316195423570985008687907853269984665640564039457584007913129639935_u256,
+                    'timestamp should be max u256',
+                );
             },
             Result::Err(e) => {
                 println!("error: {}", e);
@@ -208,14 +211,19 @@ mod tests {
         }
 
         // Test with quoted felt252 and u256
-        let json: ByteArray = "{\"id\":\"123456\",\"name\":\"launch\",\"active\":true,\"timestamp\":\"115792089237316195423570985008687907853269984665640564039457584007913129639935\"}";
+        let json: ByteArray =
+            "{\"id\":\"123456\",\"name\":\"launch\",\"active\":true,\"timestamp\":\"115792089237316195423570985008687907853269984665640564039457584007913129639935\"}";
         let result = deserialize_from_byte_array::<Event>(json);
         match result {
             Result::Ok(event) => {
                 assert(event.id == 123456, 'id should be 123456');
                 assert(event.name == "launch", 'name should be launch');
                 assert(event.active, 'active should be true');
-                assert(event.timestamp == 115792089237316195423570985008687907853269984665640564039457584007913129639935_u256, 'timestamp should be max u256');
+                assert(
+                    event
+                        .timestamp == 115792089237316195423570985008687907853269984665640564039457584007913129639935_u256,
+                    'timestamp should be max u256',
+                );
             },
             Result::Err(e) => {
                 println!("error: {}", e);
@@ -227,11 +235,15 @@ mod tests {
     #[test]
     fn test_u128_parsing() {
         // Test with unquoted u128
-        let json: ByteArray = "{\"test_value\":340282366920938463463374607431768211455,\"description\":\"max u128\"}";
+        let json: ByteArray =
+            "{\"test_value\":340282366920938463463374607431768211455,\"description\":\"max u128\"}";
         let result = deserialize_from_byte_array::<TestBigNumber>(json);
         match result {
             Result::Ok(big_num) => {
-                assert(big_num.test_value == 340282366920938463463374607431768211455_u128, 'value should be max u128');
+                assert(
+                    big_num.test_value == 340282366920938463463374607431768211455_u128,
+                    'value should be max u128',
+                );
                 assert(big_num.description == "max u128", 'description should match');
             },
             Result::Err(e) => {
@@ -239,7 +251,7 @@ mod tests {
                 panic_with_felt252('Deserialization failed');
             },
         }
-        
+
         // Test with quoted u128
         let json: ByteArray = "{\"test_value\":\"9223372036854775808\",\"description\":\"2^63\"}";
         let result = deserialize_from_byte_array::<TestBigNumber>(json);

--- a/packages/serde_json_macro/src/lib.rs
+++ b/packages/serde_json_macro/src/lib.rs
@@ -43,6 +43,8 @@ pub fn serde_json(token_stream: TokenStream) -> ProcMacroResult {
         let if_or_else_if = if index == 0 { "if" } else { "else if" };
         let parsing_function = if member_type == "u64" {
             "parse_u64"
+        } else if member_type == "u32" {
+            "parse_u32"
         } else if member_type == "u128" {
             "parse_u128"
         } else if member_type == "u256" {


### PR DESCRIPTION
This pull request includes several changes to the `serde_json` package to improve JSON deserialization and parsing. The most important changes are the addition of a new parsing function for `u32` values, reorganization of imports, and various code formatting improvements.

### Improvements to JSON deserialization:

* [`packages/serde_json/src/parser.cairo`](diffhunk://#diff-8c1d6974df47b6fa1a8c30c78c4e55bc0df95dbee10e1dd2f5d0208e87e1c00aL250-R289): Added a new function `parse_u32` for parsing `u32` values from JSON data.
* [`packages/serde_json/src/traits.cairo`](diffhunk://#diff-0b60b41dfb4bf9d6af75083a5d0f73267bf5bf51077483ec7f851f6d08d6cae6R15-R21): Implemented `JsonDeserialize` for `u32` type.

### Reorganization of imports:

* [`packages/serde_json/src/lib.cairo`](diffhunk://#diff-977e323607895645e05b3d7240b427bb754d554ec0e342429f7b61e09b393ac4R3-L8): Reorganized import statements for better readability and consistency.
* [`packages/serde_json/src/parser.cairo`](diffhunk://#diff-8c1d6974df47b6fa1a8c30c78c4e55bc0df95dbee10e1dd2f5d0208e87e1c00aR1-R7): Reorganized import statements for better readability and consistency.

### Code formatting improvements:

* [`packages/serde_json/src/parser.cairo`](diffhunk://#diff-8c1d6974df47b6fa1a8c30c78c4e55bc0df95dbee10e1dd2f5d0208e87e1c00aL62-R62): Removed unnecessary semicolons and improved code formatting in various functions. [[1]](diffhunk://#diff-8c1d6974df47b6fa1a8c30c78c4e55bc0df95dbee10e1dd2f5d0208e87e1c00aL62-R62) [[2]](diffhunk://#diff-8c1d6974df47b6fa1a8c30c78c4e55bc0df95dbee10e1dd2f5d0208e87e1c00aL90-R90) [[3]](diffhunk://#diff-8c1d6974df47b6fa1a8c30c78c4e55bc0df95dbee10e1dd2f5d0208e87e1c00aL103-R108) [[4]](diffhunk://#diff-8c1d6974df47b6fa1a8c30c78c4e55bc0df95dbee10e1dd2f5d0208e87e1c00aL130-R130) [[5]](diffhunk://#diff-8c1d6974df47b6fa1a8c30c78c4e55bc0df95dbee10e1dd2f5d0208e87e1c00aL151-L159) [[6]](diffhunk://#diff-8c1d6974df47b6fa1a8c30c78c4e55bc0df95dbee10e1dd2f5d0208e87e1c00aL179-R177) [[7]](diffhunk://#diff-8c1d6974df47b6fa1a8c30c78c4e55bc0df95dbee10e1dd2f5d0208e87e1c00aL190-R202) [[8]](diffhunk://#diff-8c1d6974df47b6fa1a8c30c78c4e55bc0df95dbee10e1dd2f5d0208e87e1c00aL218-R225) [[9]](diffhunk://#diff-8c1d6974df47b6fa1a8c30c78c4e55bc0df95dbee10e1dd2f5d0208e87e1c00aL231-R238) [[10]](diffhunk://#diff-8c1d6974df47b6fa1a8c30c78c4e55bc0df95dbee10e1dd2f5d0208e87e1c00aL263-R302) [[11]](diffhunk://#diff-8c1d6974df47b6fa1a8c30c78c4e55bc0df95dbee10e1dd2f5d0208e87e1c00aL282-R321) [[12]](diffhunk://#diff-8c1d6974df47b6fa1a8c30c78c4e55bc0df95dbee10e1dd2f5d0208e87e1c00aL295-R334)
* [`packages/serde_json/tests/test.cairo`](diffhunk://#diff-257215459358672af88c356e8ebbe789f37b3bbc4e2d8983196296a27cffffeeL1-R17): Improved formatting of JSON strings in test cases for better readability. [[1]](diffhunk://#diff-257215459358672af88c356e8ebbe789f37b3bbc4e2d8983196296a27cffffeeL1-R17) [[2]](diffhunk://#diff-257215459358672af88c356e8ebbe789f37b3bbc4e2d8983196296a27cffffeeL33-R38) [[3]](diffhunk://#diff-257215459358672af88c356e8ebbe789f37b3bbc4e2d8983196296a27cffffeeL157-R167) [[4]](diffhunk://#diff-257215459358672af88c356e8ebbe789f37b3bbc4e2d8983196296a27cffffeeL211-R226) [[5]](diffhunk://#diff-257215459358672af88c356e8ebbe789f37b3bbc4e2d8983196296a27cffffeeL230-R246)
* [`packages/serde_json_macro/src/lib.rs`](diffhunk://#diff-b8f9bbfcd0c74c299620a15984617a9486efc1d65ebc82f256f0827ea8d7a465R46-R47): Added `parse_u32` to the macro for JSON deserialization.